### PR TITLE
Fix fleet CI token migration and requirements startup_failure

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -23,15 +23,24 @@ jobs:
     name: Sync labels
     runs-on: ubuntu-22.04
     steps:
+      - name: Create App installation token
+        id: dlrsp-token
+        uses: DLRSP/workflows/.github/actions/dlrsp-actions-token@main
+        with:
+          github-app-id: ${{ secrets.DLRSP_ACTIONS_APP_ID }}
+          github-app-private-key: ${{ secrets.DLRSP_ACTIONS_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-metadata: read
+
       - uses: actions/checkout@v6
       - name: Sync labels
         uses: julb/action-manage-label@1.0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
         with:
           skip_delete: true
           from: |
-            https://raw.githubusercontent.com/DLRSP/workflows/vmain/.github/labels.yaml
+            https://raw.githubusercontent.com/DLRSP/workflows/main/.github/labels.yaml
             ${{ inputs.extra-label-files }}
             ${{ startsWith(github.event.repository.name, 'awesome-') &&
             'https://raw.githubusercontent.com/DLRSP/workflows/main/.github/labels-awesome.yaml' || '' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -184,14 +184,26 @@ jobs:
       && github.ref != 'refs/heads/prepare-release'
       && (! contains(github.event.commits.*.message, '[changelog] Post-release version bump'))
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
     # XXX We need to manually manage the life-cycle of issues created in this job because the create-issue-from-file
     # action blindy creates issues ad-nauseum. See: https://github.com/peter-evans/create-issue-from-file/issues/298 .
     # This was also discussed at: https://github.com/lycheeverse/lychee-action/issues/74#issuecomment-1587089689
     steps:
+      - name: Create App installation token
+        id: dlrsp-token
+        uses: DLRSP/workflows/.github/actions/dlrsp-actions-token@main
+        with:
+          github-app-id: ${{ secrets.DLRSP_ACTIONS_APP_ID }}
+          github-app-private-key: ${{ secrets.DLRSP_ACTIONS_PRIVATE_KEY }}
+          permission-issues: write
+          permission-metadata: read
+
       - uses: actions/checkout@v6
       - uses: lycheeverse/lychee-action@v2.7.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
         with:
           # XXX Skip twitter.com which is blackholing requests from GitHub, and HN because of rate-limiting.
           # See: https://github.com/lycheeverse/lychee/issues/989#issuecomment-1587208730
@@ -202,20 +214,16 @@ jobs:
             --verbose
             --no-progress
             './**/*.md' './**/*.html' './**/*.rst'
-      - name: Install hub
-        run: |
-          sudo apt install --yes hub
       - name: List open issues
         id: open_issues
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-        run: >
-          echo "issues=$(
-          hub issue
-          --state open
-          --creator "github-actions[bot]"
-          --format $'%I %t\t'
-          --sort created )" >> "$GITHUB_OUTPUT"
+          GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
+        run: |
+          issues="$(gh issue list --repo "${{ github.repository }}" --state open \
+            --json number,title,author \
+            --jq '.[] | select(.title=="Broken links") | "\(.number) \(.title)"' \
+            | tr '\n' '\t')"
+          echo "issues=${issues}" >> "$GITHUB_OUTPUT"
       - name: Print open issues
         run: |
           echo "Open issues: ${{ steps.open_issues.outputs.issues }}"
@@ -266,11 +274,11 @@ jobs:
       - name: Close old issues
         if: steps.issue_groups.outputs.close_issues
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
         run: |
           NUMBER_LIST="${{ steps.issue_groups.outputs.close_issues }}"
           for number in $NUMBER_LIST; do
-              hub issue update "$number" --state closed;
+              gh issue close "$number" --repo "${{ github.repository }}";
           done
       - name: Get label
         if: fromJSON(steps.issue_groups.outputs.broken_links_found)
@@ -281,6 +289,8 @@ jobs:
       - name: Create or update issue
         if: fromJSON(steps.issue_groups.outputs.broken_links_found)
         uses: peter-evans/create-issue-from-file@v6.0.0
+        env:
+          GITHUB_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
         with:
           title: "Broken links"
           issue-number: ${{ steps.issue_groups.outputs.update_issue }}

--- a/.github/workflows/pr-label-merge-conflicts.yaml
+++ b/.github/workflows/pr-label-merge-conflicts.yaml
@@ -2,7 +2,6 @@
 name: Auto label merge conflicts
 
 permissions:
-  issues: write
   pull-requests: write
 
 on:
@@ -17,10 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Create App installation token
+        id: dlrsp-token
+        uses: DLRSP/workflows/.github/actions/dlrsp-actions-token@main
+        with:
+          github-app-id: ${{ secrets.DLRSP_ACTIONS_APP_ID }}
+          github-app-private-key: ${{ secrets.DLRSP_ACTIONS_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-metadata: read
+
       - name: Label merge conflicts
         id: label
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
         run: |
           set -euo pipefail
           label="🔀 needs rebase or merge"

--- a/.github/workflows/pr-policy-gate.yaml
+++ b/.github/workflows/pr-policy-gate.yaml
@@ -111,7 +111,11 @@ jobs:
           permission-metadata: read
 
       - name: Approve pull request
-        if: steps.evaluate.outputs.decision == 'approve' && contains(steps.evaluate.outputs.actions, 'approve')
+        if: >-
+          steps.evaluate.outputs.decision == 'approve'
+          && contains(steps.evaluate.outputs.actions, 'approve')
+          && github.event.pull_request.user.login != 'app/dlrsp-actions'
+          && github.event.pull_request.user.login != 'dlrsp-actions[bot]'
         run: gh pr review --approve "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
@@ -121,7 +125,20 @@ jobs:
           steps.evaluate.outputs.decision == 'approve'
           && contains(steps.evaluate.outputs.actions, 'enable_auto_merge')
           && inputs.enable-auto-merge
+          && github.event.pull_request.user.login != 'app/dlrsp-actions'
+          && github.event.pull_request.user.login != 'dlrsp-actions[bot]'
         run: gh pr merge --auto --rebase "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
+
+      - name: Merge self-authored bot PR
+        if: >-
+          steps.evaluate.outputs.decision == 'approve'
+          && contains(steps.evaluate.outputs.actions, 'enable_auto_merge')
+          && inputs.enable-auto-merge
+          && (github.event.pull_request.user.login == 'app/dlrsp-actions'
+          || github.event.pull_request.user.login == 'dlrsp-actions[bot]')
+        run: gh pr merge --rebase --admin "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
 

--- a/.github/workflows/release-lock-patch.yaml
+++ b/.github/workflows/release-lock-patch.yaml
@@ -329,9 +329,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Create App installation token
+        id: dlrsp-token
+        uses: DLRSP/workflows/.github/actions/dlrsp-actions-token@main
+        with:
+          github-app-id: ${{ secrets.DLRSP_ACTIONS_APP_ID }}
+          github-app-private-key: ${{ secrets.DLRSP_ACTIONS_PRIVATE_KEY }}
+          permission-contents: write
+          permission-metadata: read
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.dlrsp-token.outputs.token }}
 
       - uses: actions/setup-python@v6
         with:
@@ -420,10 +430,12 @@ jobs:
         if: steps.is-patch-release.outputs.is_patch == 'true' && steps.check-tag.outputs.exists == 'false'
         run: |
           VERSION="${{ steps.extract-version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "dlrsp-actions[bot]"
+          git config user.email "293736084+dlrsp-actions[bot]@users.noreply.github.com"
           git tag -a "v${VERSION}" -m "Release v${VERSION} — runtime lock upgrades"
           git push origin "v${VERSION}"
+        env:
+          GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
 
       - name: Create GitHub Release
         if: steps.is-patch-release.outputs.is_patch == 'true' && steps.check-tag.outputs.exists == 'false'
@@ -435,4 +447,4 @@ jobs:
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.dlrsp-token.outputs.token }}

--- a/.github/workflows/release-requirements.yaml
+++ b/.github/workflows/release-requirements.yaml
@@ -417,8 +417,8 @@ jobs:
 
       - name: Setup Git
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "dlrsp-actions[bot]"
+          git config --global user.email "293736084+dlrsp-actions[bot]@users.noreply.github.com"
 
       - name: Create release branch and commit
         run: |
@@ -494,9 +494,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Create App installation token
+        id: dlrsp-token
+        uses: DLRSP/workflows/.github/actions/dlrsp-actions-token@main
+        with:
+          github-app-id: ${{ secrets.DLRSP_ACTIONS_APP_ID }}
+          github-app-private-key: ${{ secrets.DLRSP_ACTIONS_PRIVATE_KEY }}
+          permission-contents: write
+          permission-metadata: read
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.dlrsp-token.outputs.token }}
 
       - uses: actions/setup-python@v6
         with:
@@ -647,10 +657,12 @@ jobs:
         if: steps.is-patch-release.outputs.is_patch == 'true' && steps.check-tag.outputs.exists == 'false' && steps.extract-version.outputs.version != ''
         run: |
           VERSION="${{ steps.extract-version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "dlrsp-actions[bot]"
+          git config user.email "293736084+dlrsp-actions[bot]@users.noreply.github.com"
           git tag -a "v${VERSION}" -m "Release v${VERSION} - Requirements Updates"
           git push origin "v${VERSION}"
+        env:
+          GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
 
       - name: Create GitHub Release
         if: steps.is-patch-release.outputs.is_patch == 'true' && steps.check-tag.outputs.exists == 'false' && steps.extract-version.outputs.version != ''
@@ -663,5 +675,5 @@ jobs:
           prerelease: false
           generate_release_notes: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
 

--- a/.github/workflows/update-used-in.yaml
+++ b/.github/workflows/update-used-in.yaml
@@ -47,7 +47,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install --upgrade pip PyGithub
+        run: pip install --upgrade pip PyGithub PyYAML
 
       - name: Update README (workflows consumers)
         env:

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,12 @@
 - Tolerate rebased dependabot commits in policy gate (`skip-commit-verification` + body fallback).
 - Mark Python 3.9 and py3.13/3.14 django verify matrix legs as optional.
 - Route all policy-gate PR writes (approve, block label, block comment) through `dlrsp-actions` App token.
+- Fix `labels.yaml` canonical URL (`main`, not `vmain`); sync labels via App token.
+- Fix `update-used-in` central job missing `PyYAML`.
+- Drop spurious `issues: write` from `pr-label-merge-conflicts` (fixes requirements `startup_failure`).
+- Migrate merge-conflict labels and broken-link issues to `dlrsp-actions` App token.
+- Trust `app/dlrsp-actions` PR author; skip self-approve; admin-merge self-authored bot PRs.
+- Release tag pushes use `dlrsp-actions[bot]` git identity and App token.
 
 ## [1.19.0 (2026-06-15)](https://github.com/DLRSP/workflows/compare/v1.18.3...v1.19.0)
 

--- a/policies/bot-policy-requirements.yaml
+++ b/policies/bot-policy-requirements.yaml
@@ -1,6 +1,7 @@
 version: 1
 trusted_actors:
   - dlrsp-actions[bot]
+  - app/dlrsp-actions
   - dependabot[bot]
   - pre-commit-ci[bot]
 shim_actors:

--- a/policies/bot-policy-workflows.yaml
+++ b/policies/bot-policy-workflows.yaml
@@ -1,6 +1,7 @@
 version: 1
 trusted_actors:
   - dlrsp-actions[bot]
+  - app/dlrsp-actions
   - dependabot[bot]
   - pre-commit-ci[bot]
 shim_actors:

--- a/policies/bot-policy.yaml
+++ b/policies/bot-policy.yaml
@@ -1,6 +1,7 @@
 version: 1
 trusted_actors:
   - dlrsp-actions[bot]
+  - app/dlrsp-actions
   - dependabot[bot]
   - pre-commit-ci[bot]
 shim_actors:


### PR DESCRIPTION
## Summary
- Drop spurious issues:write from pr-label-merge-conflicts (fixes requirements main startup_failure P-012)
- Trust app/dlrsp-actions in bot policies; skip self-approve; admin-merge self-authored bot PRs (P-013)
- Fix labels.yaml vmain typo; sync labels via dlrsp-actions App token (P-014)
- Migrate broken-link issue lifecycle to App token; fix update-used-in PyYAML
- Release tag pushes use dlrsp-actions[bot] identity and App token

## Test plan
- [ ] requirements main workflow no longer startup_failure
- [ ] workflows labels + update-used-in jobs green on main push
- [ ] dlrsp-actions PR #1231 policy gate merges with admin merge
- [ ] dependabot PRs still approve + auto-merge when CI green