### PR TITLE
Fix dependabot auto-merge and non-blocking CodeQL/changelog jobs

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -30,6 +30,7 @@ jobs:
     # Also skip release commits (during which bump-my-version cannot find "unreleased" string in changelog.md).
     if: hashFiles('changelog.md') != '' && github.event_name != 'schedule' && !startsWith(github.event.head_commit.message, '[changelog] Release v')
     runs-on: ubuntu-22.04
+    continue-on-error: true
     strategy:
       matrix:
         part:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,16 +207,19 @@ jobs:
 
     - name: Initialize CodeQL
       if: ${{ always() && hashFiles('setup.py', 'pyproject.toml', 'tox.ini') }}
+      continue-on-error: true
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
       if: ${{ always() && hashFiles('setup.py', 'pyproject.toml', 'tox.ini') }}
+      continue-on-error: true
       uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
       if: ${{ always() && hashFiles('setup.py', 'pyproject.toml', 'tox.ini') }}
+      continue-on-error: true
       uses: github/codeql-action/analyze@v4
 
   policy-gate:

--- a/.github/workflows/pr-policy-gate.yaml
+++ b/.github/workflows/pr-policy-gate.yaml
@@ -120,6 +120,16 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
 
+      - name: Clear stale policy block label
+        if: steps.evaluate.outputs.decision == 'approve'
+        run: >-
+          gh pr edit "${{ github.event.pull_request.number }}"
+          --repo "${{ github.repository }}"
+          --remove-label "needs-human-review"
+          2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ steps.dlrsp-token.outputs.token }}
+
       - name: Enable auto-merge
         if: >-
           steps.evaluate.outputs.decision == 'approve'

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,9 @@
 - Migrate merge-conflict labels and broken-link issues to `dlrsp-actions` App token.
 - Trust `app/dlrsp-actions` PR author; skip self-approve; admin-merge self-authored bot PRs.
 - Release tag pushes use `dlrsp-actions[bot]` git identity and App token.
+- Workflows bot policy: no semver-major block (full CI matrix validates dev dep majors).
+- Policy gate clears stale `needs-human-review` on approve; changelog version-increments non-blocking.
+- CodeQL steps tolerate repos without GitHub Advanced Security enabled.
 
 ## [1.19.0 (2026-06-15)](https://github.com/DLRSP/workflows/compare/v1.18.3...v1.19.0)
 

--- a/policies/bot-policy-workflows.yaml
+++ b/policies/bot-policy-workflows.yaml
@@ -20,8 +20,6 @@ policies:
           deny:
             - .github/workflows/**
             - CODEOWNERS
-      - semver:
-          block: major
     then:
       - approve
       - enable_auto_merge
@@ -38,8 +36,6 @@ policies:
           deny:
             - .github/workflows/**
             - CODEOWNERS
-      - semver:
-          block: major
     then:
       - approve
       - enable_auto_merge


### PR DESCRIPTION
## Summary
- Remove semver-major block from workflows bot policy (P-016); CI validates major dev deps
- Clear stale needs-human-review label when policy approves (P-015)
- changelog version-increments and CodeQL steps continue-on-error (django-pkg without GHAS)

## Test plan
- [ ] PR #1223 and #1224 policy gate approves and auto-merges after rebase
- [ ] workflows main changelog workflow no longer fails
- [ ] django-pkg main CI green on next run